### PR TITLE
Python3 Support

### DIFF
--- a/python/ibmos2spark/__info__.py
+++ b/python/ibmos2spark/__info__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.0.8-dev'
+__version__ = '0.0.9-dev'

--- a/python/ibmos2spark/__info__.py
+++ b/python/ibmos2spark/__info__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.0.9-dev'
+__version__ = '0.0.8-dev'

--- a/python/ibmos2spark/__init__.py
+++ b/python/ibmos2spark/__init__.py
@@ -16,5 +16,4 @@
 Helper to connect to Softlayer and Bluemix ObjectStore from IBM Spark Service
 """
 from .__info__ import __version__
-from osconfig import softlayer, bluemix, softlayer2d, bluemix2d
-
+from .osconfig import softlayer, bluemix, softlayer2d, bluemix2d


### PR DESCRIPTION
**Background**

Currently, the lib can't be imported in python3. The user will get an exception that complains that the file `osconfig` is not found. The reason behind it is that python3 requires the `.` for relative paths for this case.

Link:
https://stackoverflow.com/questions/12172791/changes-in-import-statement-python3

This PR solves this.